### PR TITLE
[feat]: #86 구독 버튼 누를 시 키워드가 CoreData에 저장 

### DIFF
--- a/Ninano/Ninano/Controllers/EventTab/SearchResult/SearchResultViewController.swift
+++ b/Ninano/Ninano/Controllers/EventTab/SearchResult/SearchResultViewController.swift
@@ -14,8 +14,8 @@ final class SearchResultViewController: UIViewController, UISearchBarDelegate{
     @IBOutlet private weak var keywordNotification: UIButton!
     @IBOutlet private weak var keywordAddedNotification: UIStackView!
     @IBOutlet private weak var eventCollectionView: UICollectionView!
-    var searchBar = UISearchBar(frame: CGRect(x: 0, y: 0, width: 300, height: 0))
-    var keywordViewModel = KeywordDataModel()
+    private var searchBar = UISearchBar(frame: CGRect(x: 0, y: 0, width: 300, height: 0))
+    private var keywordViewModel = KeywordDataModel()
     
     var eventList: [Event] = []
     var viewCatagory: SearchDetailCatagory?

--- a/Ninano/Ninano/Controllers/EventTab/SearchResult/SearchResultViewController.swift
+++ b/Ninano/Ninano/Controllers/EventTab/SearchResult/SearchResultViewController.swift
@@ -7,7 +7,7 @@
 
 import UIKit
 
-final class SearchResultViewController: UIViewController {
+final class SearchResultViewController: UIViewController, UISearchBarDelegate{
     
     @IBOutlet weak var eventFilterButton: EventFilterButton!
     @IBOutlet private var performanceCollectionView: UICollectionView!
@@ -15,6 +15,8 @@ final class SearchResultViewController: UIViewController {
     @IBOutlet private weak var keywordAddedNotification: UIStackView!
     @IBOutlet private weak var eventCollectionView: UICollectionView!
     private var isNotificationButtonSelected = false
+    var searchBar = UISearchBar(frame: CGRect(x: 0, y: 0, width: 300, height: 0))
+    var keywordViewModel = KeywordDataModel()
     
     var eventList: [Event] = []
     var viewCatagory: SearchDetailCatagory?
@@ -26,6 +28,7 @@ final class SearchResultViewController: UIViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
+        searchBar.delegate = self
         keywordAddedNotification.isHidden = true
         // collectionView에 대한 설정
         performanceCollectionView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
@@ -44,10 +47,9 @@ final class SearchResultViewController: UIViewController {
                 let searchCatagoryTitle = UILabel(frame: CGRect(x: 0, y: 0, width: 200, height: 20))
                 searchCatagoryTitle.textAlignment = .center
                 searchCatagoryTitle.font = UIFont.systemFont(ofSize: 20)
-                    searchCatagoryTitle.text = navigationTitle
+                searchCatagoryTitle.text = navigationTitle
                 self.navigationItem.titleView = searchCatagoryTitle
             case .searchResult:
-                let searchBar = UISearchBar(frame: CGRect(x: 0, y: 0, width: 300, height: 0))
                 searchBar.placeholder = "Search User"
                 self.navigationItem.rightBarButtonItem = UIBarButtonItem(customView: searchBar)
             case .none:
@@ -57,11 +59,25 @@ final class SearchResultViewController: UIViewController {
         keywordNotification.layer.cornerRadius = 15
     }
     
+    internal func searchBarSearchButtonClicked(_ searchBar: UISearchBar) {
+        dismissKeyboard(searchBar)
+    }
+    
+    internal func searchBar(_ searchBar: UISearchBar, textDidChange searchText: String) {
+        // TODO: filter collectionView
+//        print("searchText",searchText)
+    }
+    
+    private func dismissKeyboard(_ searchBar: UISearchBar) {
+        searchBar.resignFirstResponder()
+    }
+    
     @objc private func didTapBackButton() {
         self.navigationController?.popViewController(animated: true)
     }
     
     @IBAction private func keywordNotificationButton(_ sender: UIButton) {
+        keywordViewModel.addKeywordItems(keyword: (String(describing: searchBar.text)))
     }
     
     @IBAction private func notificationSettingsButton(_ sender: UIButton) {
@@ -80,6 +96,10 @@ final class SearchResultViewController: UIViewController {
         }
     }
 }
+
+//keywordViewModel.keywordItems.forEach { keywordList in
+//    print(keywordList.keywordSubs)
+//}
 
 extension SearchResultViewController: UICollectionViewDelegateFlowLayout {
     

--- a/Ninano/Ninano/Controllers/EventTab/SearchResult/SearchResultViewController.swift
+++ b/Ninano/Ninano/Controllers/EventTab/SearchResult/SearchResultViewController.swift
@@ -14,7 +14,6 @@ final class SearchResultViewController: UIViewController, UISearchBarDelegate{
     @IBOutlet private weak var keywordNotification: UIButton!
     @IBOutlet private weak var keywordAddedNotification: UIStackView!
     @IBOutlet private weak var eventCollectionView: UICollectionView!
-    private var isNotificationButtonSelected = false
     var searchBar = UISearchBar(frame: CGRect(x: 0, y: 0, width: 300, height: 0))
     var keywordViewModel = KeywordDataModel()
     
@@ -30,6 +29,7 @@ final class SearchResultViewController: UIViewController, UISearchBarDelegate{
         super.viewDidLoad()
         searchBar.delegate = self
         keywordAddedNotification.isHidden = true
+        keywordNotification.isHidden = true
         // collectionView에 대한 설정
         performanceCollectionView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
         performanceCollectionView.dataSource = self
@@ -55,17 +55,25 @@ final class SearchResultViewController: UIViewController, UISearchBarDelegate{
             case .none:
                 print("viewCatagory error")
         }
-        
+        keywordAddedNotification.layer.cornerRadius = 15
         keywordNotification.layer.cornerRadius = 15
     }
     
     internal func searchBarSearchButtonClicked(_ searchBar: UISearchBar) {
         dismissKeyboard(searchBar)
+        
+        let isKeywordInCoreData = keywordViewModel.keywordItems.contains { keywordList in
+            return keywordList.keywordSubs == searchBar.text
+        }
+        if isKeywordInCoreData {
+            keywordNotification.isHidden = true
+        } else {
+            keywordNotification.isHidden = false
+        }
     }
     
     internal func searchBar(_ searchBar: UISearchBar, textDidChange searchText: String) {
-        // TODO: filter collectionView
-//        print("searchText",searchText)
+        // TODO: filter CollectionView
     }
     
     private func dismissKeyboard(_ searchBar: UISearchBar) {
@@ -77,29 +85,18 @@ final class SearchResultViewController: UIViewController, UISearchBarDelegate{
     }
     
     @IBAction private func keywordNotificationButton(_ sender: UIButton) {
-        keywordViewModel.addKeywordItems(keyword: (String(describing: searchBar.text)))
-    }
-    
-    @IBAction private func notificationSettingsButton(_ sender: UIButton) {
-        // TODO: 키워드 값 넣는 로직
-        if isNotificationButtonSelected == false {
-            keywordAddedNotification.isHidden = false
-            keywordAddedNotification.layer.cornerRadius = 15
-            sender.isHidden = true
-            
-            isNotificationButtonSelected = true
-            DispatchQueue.main.asyncAfter(deadline: .now() + 2) {
-                UIView.animate(withDuration: 1) {
-                    self.keywordAddedNotification.isHidden = true
-                }
+        if let keyWord = searchBar.text {
+            keywordViewModel.addKeywordItems(keyword: keyWord)
+        }
+        keywordAddedNotification.isHidden = false
+        keywordNotification.isHidden = true
+        DispatchQueue.main.asyncAfter(deadline: .now() + 2) {
+            UIView.animate(withDuration: 1) {
+                self.keywordAddedNotification.isHidden = true
             }
         }
     }
 }
-
-//keywordViewModel.keywordItems.forEach { keywordList in
-//    print(keywordList.keywordSubs)
-//}
 
 extension SearchResultViewController: UICollectionViewDelegateFlowLayout {
     

--- a/Ninano/Ninano/Views/EventTab/SerchResult/SearchResult.storyboard
+++ b/Ninano/Ninano/Views/EventTab/SerchResult/SearchResult.storyboard
@@ -132,7 +132,6 @@
                                 </state>
                                 <connections>
                                     <action selector="keywordNotificationButton:" destination="Y6W-OH-hqX" eventType="touchUpInside" id="VSv-mh-EWE"/>
-                                    <action selector="notificationSettingsButton:" destination="Y6W-OH-hqX" eventType="touchUpInside" id="Hys-K6-mVx"/>
                                 </connections>
                             </button>
                             <stackView opaque="NO" alpha="0.80000000000000004" contentMode="scaleToFill" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="Wdi-el-Pla">


### PR DESCRIPTION
# Issue Number
🔒 Close #86

## Pull Request 내용 (변경 및 추가된 사항들)
- [x] 사용자가 구독 버튼 누를 시 키워드가 CoreData에 저장
- [x] 이미 구독된 키워드는 구독 버튼이 뜨면 안됨

## Review points

## 관련 사진 gif 및 (Optional)
![ezgif com-gif-maker](https://user-images.githubusercontent.com/82457928/181675226-bd07ba8c-1a3d-4554-bee3-f43974fd5732.gif)


## Questions (Optional)

- write here

## References (Optional)
[SearchBar](https://www.youtube.com/watch?v=Lb8aJa7J4BI)
[SearchBarDelegate](https://codershigh.dscloud.biz/techblogs/tb_009_UISearchController/tb009_script.html)

## Checklist

- [x] merge할 branch를 확인했나요?
- [x] coding conventions을 지켰나요?
- [x] 이 PR에 관계없는 변경사항들이 없나요?
- [x] PR 날리는 코드를 self 리뷰 했나요?
