### PR TITLE
[feat] 지역, 날짜, 검색시 collectionView filtering 되기

### DIFF
--- a/Ninano/Ninano/Controllers/CalendarTab/Interest/NoticeViewController.swift
+++ b/Ninano/Ninano/Controllers/CalendarTab/Interest/NoticeViewController.swift
@@ -58,7 +58,7 @@ class NoticeViewController: UIViewController {
             alert.addAction(alertYes)
             alert.addAction(alertNo)
             
-/// TODO: completion 에 DATA.reloadData() 안 들어가도 될까?? -> Test 해봐야 할듯
+// TODO: completion 에 DATA.reloadData() 안 들어가도 될까?? -> Test 해봐야 할듯
             present(alert, animated: true, completion: nil)
 //            present(alert, animated: true) {
 //                <#code#>

--- a/Ninano/Ninano/Controllers/EventTab/SearchResult/SearchResultViewController.swift
+++ b/Ninano/Ninano/Controllers/EventTab/SearchResult/SearchResultViewController.swift
@@ -28,6 +28,11 @@ final class SearchResultViewController: UIViewController, UISearchBarDelegate {
             reloadCollection()
         }
     }
+    private var searchKeyword: String? {
+        didSet {
+            reloadCollection()
+        }
+    }
     
     var eventList: [Event] = []
     var copyEventList: [Event] = []
@@ -89,6 +94,29 @@ final class SearchResultViewController: UIViewController, UISearchBarDelegate {
                 filterEvent = filterEvent.filter { $0.area == compareLocal }
             }
         }
+        // searchWord 정제
+        if let searchKeyword = self.searchKeyword, searchKeyword != "" {
+            filterEvent = filterEvent.filter {
+                print(searchKeyword)
+                if $0.title.contains(searchKeyword) {
+                    return true
+                } else if let place = $0.place, place.contains(searchKeyword) {
+                    return true
+                } else if let area = $0.area, area.contains(searchKeyword) {
+                    return true
+                } else if let period = $0.period, period.contains(searchKeyword) {
+                    return true
+                } else if let actor = $0.actor, actor.contains(searchKeyword) {
+                    return true
+                } else if let info = $0.info, info.contains(searchKeyword) {
+                    return true
+                } else if let price = $0.price, price.contains(searchKeyword) {
+                    return true
+                }
+                return false
+            }
+        }
+        // collectionView update
         copyEventList = filterEvent
         performanceCollectionView.reloadData()
     }
@@ -110,7 +138,7 @@ final class SearchResultViewController: UIViewController, UISearchBarDelegate {
                 searchCatagoryTitle.text = navigationTitle
                 self.navigationItem.titleView = searchCatagoryTitle
             case .searchResult:
-                let searchBar = UISearchBar(frame: CGRect(x: 0, y: 0, width: view.frame.width - 90, height: 0))
+                self.searchBar = UISearchBar(frame: CGRect(x: 0, y: 0, width: view.frame.width - 90, height: 0))
                 searchBar.placeholder = "공연을 검색하세요"
                 self.navigationItem.rightBarButtonItem = UIBarButtonItem(customView: searchBar)
             case .none:
@@ -133,6 +161,7 @@ final class SearchResultViewController: UIViewController, UISearchBarDelegate {
     
     internal func searchBar(_ searchBar: UISearchBar, textDidChange searchText: String) {
         // TODO: filter CollectionView
+        searchKeyword = searchBar.text
     }
     
     private func dismissKeyboard(_ searchBar: UISearchBar) {

--- a/Ninano/Ninano/Model/SubscriptionModel.swift
+++ b/Ninano/Ninano/Model/SubscriptionModel.swift
@@ -24,7 +24,7 @@ struct LikeDataModel {
         LikeManager.shared.deleteLike(with: url)
     }
     
-    /// MARK: keyword 에서만 사용할 예정이지만 Test 에서 사용해보려 추가함
+    // MARK: keyword 에서만 사용할 예정이지만 Test 에서 사용해보려 추가함
     func removeAllLikeItems() {
         LikeManager.shared.deleteAll()
     }

--- a/Ninano/Ninano/TEST/APITest/TestViewController.swift
+++ b/Ninano/Ninano/TEST/APITest/TestViewController.swift
@@ -98,4 +98,3 @@ class TestViewController: UIViewController, UITableViewDelegate, UITableViewData
     }
 
 }
-

--- a/Ninano/Ninano/Views/EventTab/SerchResult/EventFilterButton.swift
+++ b/Ninano/Ninano/Views/EventTab/SerchResult/EventFilterButton.swift
@@ -49,11 +49,17 @@ class EventFilterButton: UIView {
         let locals: [String] = local
         for location in locals {
             actionSheet.addAction(UIAlertAction(title: location, style: .default, handler: { _ in
-                sender.configuration?.baseBackgroundColor = CustomColor.buttonLightRed
                 let attribute = [NSAttributedString.Key.font: UIFont.preferredFont(forTextStyle: .footnote, weight: .regular)]
-                let attributedTitle = NSAttributedString(string: location, attributes: attribute)
-                sender.setAttributedTitle(attributedTitle, for: .normal)
                 self.datedeliveryDelegate?.filterCollctionCell(criteria: .local(location))
+                if location == "전체" {
+                    sender.configuration?.baseBackgroundColor = CustomColor.buttonLightGray
+                    let attributedTitle = NSAttributedString(string: "지역 선택", attributes: attribute)
+                    sender.setAttributedTitle(attributedTitle, for: .normal)
+                } else {
+                    sender.configuration?.baseBackgroundColor = CustomColor.buttonLightRed
+                    let attributedTitle = NSAttributedString(string: location, attributes: attribute)
+                    sender.setAttributedTitle(attributedTitle, for: .normal)
+                }
             }))
         }
         actionSheet.addAction(UIAlertAction(title: "Cancel", style: .cancel, handler: nil))

--- a/Ninano/Ninano/Views/EventTab/SerchResult/EventFilterButton.swift
+++ b/Ninano/Ninano/Views/EventTab/SerchResult/EventFilterButton.swift
@@ -34,7 +34,7 @@ class EventFilterButton: UIView {
         return nib.instantiate(withOwner: self, options: nil).first as? UIView
     }
     
-    weak var datedeliveryDelegate: FilterButtonClickable?
+    weak var datedeliveryDelegate: EventButtonFilterable?
     
     private enum Filter {
         case local
@@ -42,26 +42,18 @@ class EventFilterButton: UIView {
         case date
     }
     
-    private enum LocationType: String {
-        case gangnam = "강남"
-        case gangbook = "강북"
-        case gurogu = "구로구"
-        case gwanakgu = "관악구"
-        case gwangjingu = "광진구"
-        case dobonggu = "도봉구"
-        case nowongu = "노원구"
-    }
+    var local: [String] = []
     
     @IBAction private func localFilterButton(_ sender: UIButton) {
         let actionSheet = UIAlertController(title: "지역 선택", message: "공연 정보를 나타낼 지역을 설정해주세요.", preferredStyle: .actionSheet)
-        let locals: [LocationType] = [.gangnam, .gangbook, .gurogu, .gwanakgu, .gwangjingu, .dobonggu, .nowongu]
-        for local in locals {
-            let location = local.rawValue
+        let locals: [String] = local
+        for location in locals {
             actionSheet.addAction(UIAlertAction(title: location, style: .default, handler: { _ in
                 sender.configuration?.baseBackgroundColor = CustomColor.buttonLightRed
                 let attribute = [NSAttributedString.Key.font: UIFont.preferredFont(forTextStyle: .footnote, weight: .regular)]
                 let attributedTitle = NSAttributedString(string: location, attributes: attribute)
                 sender.setAttributedTitle(attributedTitle, for: .normal)
+                self.datedeliveryDelegate?.filterCollctionCell(criteria: .local(location))
             }))
         }
         actionSheet.addAction(UIAlertAction(title: "Cancel", style: .cancel, handler: nil))

--- a/Ninano/Ninano/extension/DateFormatter.swift
+++ b/Ninano/Ninano/extension/DateFormatter.swift
@@ -10,13 +10,34 @@ import Foundation
 extension Date {
     enum DataFormatCatagory: String {
         case koreanDate = "yyyy년 MM월 dd일(EEEEE)"
+        case onlyDate = "yyyy MM dd"
     }
     
-    func convertDateToKoreanDate(_ dataFormatCatagory: DataFormatCatagory) -> String {
+    func convertDateToOtherType(_ dataFormatCatagory: DataFormatCatagory) -> String {
         let formatter = DateFormatter()
         formatter.dateFormat = dataFormatCatagory.rawValue
         formatter.locale = Locale(identifier: "ko_KR")
         let koreanDate = formatter.string(from: self)
         return koreanDate
+    }
+        public func isDateToday(fromDate: Date) -> Bool {
+            self.convertDateToOtherType(.onlyDate) == fromDate.convertDateToOtherType(.onlyDate)
+        }
+    }
+
+extension String {
+    /// self : "2022-08-10~2022-08-10: yyyy-MM-dd~yyyy-MM-dd"
+    func periodToDateList() -> [Date] {
+        // TODO: 2022-08-10~2022-09-03 -> 8월 10일 ~ 9월 3일 날짜 다 넣기 ...
+        var returnDateList: [Date] = []
+        let dateStringList = Array(Set(self.components(separatedBy: "~")))
+        let dateFormatter = DateFormatter()
+        dateFormatter.dateFormat = "yyyy-MM-dd"
+        for dateString in dateStringList {
+            if let date = dateFormatter.date(from: dateString) {
+                returnDateList.append(date)
+            }
+        }
+        return returnDateList
     }
 }


### PR DESCRIPTION
# Issue Number
🔒 Close #92
🔒 Close #93
🔒 Close #94

## Pull Request 내용 (변경 및 추가된 사항들)
- 사용자가 고른 일자에 따라 collectionView의 내용이 filtering 됩니다.
- 고른 지역구의 값에 따라 collectionView의 내용이 filtering 됩니다.
- searchbar에서 입력한 값에 따라 collectionView의 내용이 filtering 됩니다.

## Review points
- 잡버그들 연락 받습니다.. + 버그 발생 경로를 말씀해주세요 
- 참고로 2022-08-10~2022-09-03은... 저의 개발 능력 issue로  2022-08-10,  2022-08-11, ... , 2022-09-03로 인식되지 않고, 2022-08-10와 2022-09-03로 인식됩니다. 이는.. 소요 시간이 많이 들거라 판단했기 때문입니다.. 후에 급한 빅 task부터 끝낸 후에 해보겟습니다.
- 이제... collectionView의 UI를 리팩토링 하겠습니다.. 1개 뜰 때랑,, 글씨 잘리는 거.. 포스터 확대되는 거..

## 관련 사진 gif 및 (Optional)
![ezgif com-gif-maker](https://user-images.githubusercontent.com/82457928/181906529-240f9b32-2c0c-4b21-8dc5-e32a593a8b7b.gif)


## Checklist

- [x] merge할 branch를 확인했나요?
- [x] coding conventions을 지켰나요?
- [x] 이 PR에 관계없는 변경사항들이 없나요?
- [x] PR 날리는 코드를 self 리뷰 했나요?
