### PR TITLE
[Feat]: #104 공연 추천 뷰에서 카테고리 디테일로 넘어가기

### DIFF
--- a/Ninano/Ninano/Controllers/EventTab/Search/SearchViewController.swift
+++ b/Ninano/Ninano/Controllers/EventTab/Search/SearchViewController.swift
@@ -111,6 +111,7 @@ extension SearchViewController: UITableViewDelegate, UITableViewDataSource, Sear
         default:
             return UITableViewCell()
         }
+        cell.searchCategoryViewDelegate = self
         return cell
     }
     

--- a/Ninano/Ninano/Controllers/EventTab/Search/SearchViewController.swift
+++ b/Ninano/Ninano/Controllers/EventTab/Search/SearchViewController.swift
@@ -57,7 +57,18 @@ class SearchViewController: UIViewController {
     }
 }
 
-extension SearchViewController: UITableViewDelegate, UITableViewDataSource {
+protocol SearchCategoryViewShowable {
+    func didTouchCategoryButton(categoryTitle: String, eventList: [Event])
+}
+
+extension SearchViewController: UITableViewDelegate, UITableViewDataSource, SearchCategoryViewShowable {
+    func didTouchCategoryButton(categoryTitle: String, eventList: [Event]) {
+        guard let searchResultView = UIStoryboard(name: "SearchResult", bundle: .main).instantiateViewController(withIdentifier: "SearchResultViewController") as? SearchResultViewController else { return }
+        searchResultView.eventList = eventList
+        searchResultView.viewCatagory = .searchCatagory(navigationTitle: categoryTitle)
+        self.navigationController?.pushViewController(searchResultView, animated: true)
+    }
+    
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
         return Category.allCases.count
     }
@@ -69,6 +80,8 @@ extension SearchViewController: UITableViewDelegate, UITableViewDataSource {
         let categoryTitle = Category.allValues[indexPath.row].rawValue
         let attribute = [NSAttributedString.Key.font: UIFont.preferredFont(forTextStyle: .subheadline, weight: .semibold)]
         let attributedTitle = NSAttributedString(string: categoryTitle, attributes: attribute)
+        
+        cell.categoryTitle = categoryTitle
         cell.categoryName.setAttributedTitle(attributedTitle, for: .normal)
         cell.categoryName.titleLabel?.adjustsFontForContentSizeCategory = true
         

--- a/Ninano/Ninano/Views/EventTab/Search/CategoryCell.swift
+++ b/Ninano/Ninano/Views/EventTab/Search/CategoryCell.swift
@@ -8,6 +8,7 @@
 import UIKit
 
 class CategoryCell: UITableViewCell {
+    var categoryTitle: String?
     var eventList: [Event] = [] {
         // MARK: fetchTopStories()에서 viewModels를 가져오는데 시간이 걸리므로 가져온 후 eventCollectionView를 reload 함.
         didSet {
@@ -18,6 +19,12 @@ class CategoryCell: UITableViewCell {
     @IBOutlet weak var categoryName: UIButton!
     @IBOutlet weak var categoryChevron: UIButton!
     @IBOutlet weak var eventCollectionView: UICollectionView!
+    
+    var searchCategoryViewDelegate: SearchCategoryViewShowable?
+    
+    @IBAction func didTapCategoryName(_ sender: UIButton) {
+        searchCategoryViewDelegate?.didTouchCategoryButton(categoryTitle: categoryTitle ?? "", eventList: eventList)
+    }
 }
 
 extension CategoryCell: UICollectionViewDelegateFlowLayout {

--- a/Ninano/Ninano/Views/EventTab/Search/Search.storyboard
+++ b/Ninano/Ninano/Views/EventTab/Search/Search.storyboard
@@ -41,6 +41,9 @@
                                                         <fontDescription key="titleFontDescription" style="UICTFontTextStyleSubhead"/>
                                                         <color key="baseForegroundColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                     </buttonConfiguration>
+                                                    <connections>
+                                                        <action selector="didTapCategoryName:" destination="sAV-Tq-CcU" eventType="touchUpInside" id="qxE-Yj-e6a"/>
+                                                    </connections>
                                                 </button>
                                                 <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="dGT-8G-rJs">
                                                     <rect key="frame" x="370.5" y="10" width="33.5" height="28.5"/>
@@ -66,7 +69,7 @@
                                                         <inset key="sectionInset" minX="25" minY="0.0" maxX="0.0" maxY="0.0"/>
                                                     </collectionViewFlowLayout>
                                                     <cells>
-                                                        <collectionViewCell opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" reuseIdentifier="eventCell" translatesAutoresizingMaskIntoConstraints="NO" id="par-6b-w9q" customClass="EventCell" customModule="Ninano" customModuleProvider="target">
+                                                        <collectionViewCell opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" fixedFrame="YES" reuseIdentifier="eventCell" translatesAutoresizingMaskIntoConstraints="NO" id="par-6b-w9q" customClass="EventCell" customModule="Ninano" customModuleProvider="target">
                                                             <rect key="frame" x="25" y="7" width="104" height="139"/>
                                                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                                             <collectionViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" id="V98-ha-uVI">


### PR DESCRIPTION
# Issue Number
🔒 Close #104 

## Pull Request 내용 (변경 및 추가된 사항들)
- 카테고리 누르면 카테고리 디테일 페이지로 넘어갑니다!
- @rriver2 감사합니다!!

## Review points

- 없음..갓리버

## 관련 사진 gif 및 (Optional)
![Jul-30-2022 18-25-04](https://user-images.githubusercontent.com/103012157/181904309-c75c5899-bb73-42d6-8226-b7c5d8671fff.gif)

## References (Optional)

- @rriver2 의 카톡 설명을 여기에 옮깁니다.
> cell에서는 navigation으로 갈 수 없다. 그래서 cell에서 그 상위 View인 SearchView에 delegate를 설정해서 cell에서 SearchView에 있는 searchCatagoryView로 연결하는 함수를 호출했다.

## Checklist

- [x] merge할 branch를 확인했나요?
- [x] coding conventions을 지켰나요?
- [x] 이 PR에 관계없는 변경사항들이 없나요?
- [x] PR 날리는 코드를 self 리뷰 했나요?
