### PR TITLE
SearchResultView color Hifi랑 동일하게 하기

### DIFF
--- a/Ninano/Ninano/Controllers/EventTab/SearchResult/SearchResultViewController.swift
+++ b/Ninano/Ninano/Controllers/EventTab/SearchResult/SearchResultViewController.swift
@@ -204,6 +204,7 @@ extension SearchResultViewController: UICollectionViewDelegateFlowLayout {
         let spacing = (14 / 390) * screen
         
         let width = (screen - (inset * 2) - spacing) / 2
+        
         // TODO: gaeun 변경
         let height = (4 / 3) * width + 65
         

--- a/Ninano/Ninano/Controllers/EventTab/SearchResult/SearchResultViewController.swift
+++ b/Ninano/Ninano/Controllers/EventTab/SearchResult/SearchResultViewController.swift
@@ -233,6 +233,7 @@ extension SearchResultViewController: UICollectionViewDataSource, UICollectionVi
         
         return PerformancesViewCell()
     }
+    /// 셀을 선택했을 때 액션 추가 가능
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
         guard let eventDetailView = UIStoryboard(name: "EventDetail", bundle: .main).instantiateViewController(withIdentifier: "EventDetailViewController") as? EventDetailViewController else { return }
         eventDetailView.event = self.copyEventList[indexPath.item]

--- a/Ninano/Ninano/Controllers/EventTab/SearchResult/SearchResultViewController.swift
+++ b/Ninano/Ninano/Controllers/EventTab/SearchResult/SearchResultViewController.swift
@@ -195,6 +195,7 @@ final class SearchResultViewController: UIViewController, UISearchBarDelegate {
 
 extension SearchResultViewController: UICollectionViewDelegateFlowLayout {
     
+    // collection
     func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
         
         guard let flow = collectionViewLayout as? UICollectionViewFlowLayout else { return CGSize() }
@@ -203,6 +204,7 @@ extension SearchResultViewController: UICollectionViewDelegateFlowLayout {
         let spacing = (14 / 390) * screen
         
         let width = (screen - (inset * 2) - spacing) / 2
+        // TODO: gaeun 변경
         let height = (4 / 3) * width + 65
         
         flow.minimumLineSpacing = spacing

--- a/Ninano/Ninano/Controllers/EventTab/SearchResult/SearchResultViewController.swift
+++ b/Ninano/Ninano/Controllers/EventTab/SearchResult/SearchResultViewController.swift
@@ -205,7 +205,6 @@ extension SearchResultViewController: UICollectionViewDelegateFlowLayout {
         
         let width = (screen - (inset * 2) - spacing) / 2
         
-        // TODO: gaeun 변경
         let height = (4 / 3) * width + 65
         
         flow.minimumLineSpacing = spacing

--- a/Ninano/Ninano/Views/EventTab/SerchResult/EventFilterButton.xib
+++ b/Ninano/Ninano/Views/EventTab/SerchResult/EventFilterButton.xib
@@ -16,49 +16,46 @@
         </placeholder>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
         <view contentMode="scaleToFill" id="iN0-l3-epB">
-            <rect key="frame" x="0.0" y="0.0" width="213" height="30"/>
+            <rect key="frame" x="0.0" y="0.0" width="360" height="30"/>
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
-                <stackView opaque="NO" contentMode="scaleToFill" distribution="fillProportionally" spacing="14" translatesAutoresizingMaskIntoConstraints="NO" id="7Dh-m2-hwN">
-                    <rect key="frame" x="0.0" y="0.0" width="213" height="30"/>
-                    <subviews>
-                        <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="1ff-yL-qJn">
-                            <rect key="frame" x="0.0" y="0.0" width="96.5" height="30"/>
-                            <color key="tintColor" systemColor="labelColor"/>
-                            <state key="normal" title="Button"/>
-                            <buttonConfiguration key="configuration" style="gray" title="지역설정" cornerStyle="capsule">
-                                <fontDescription key="titleFontDescription" style="UICTFontTextStyleFootnote"/>
-                                <color key="baseBackgroundColor" systemColor="systemGray5Color"/>
-                            </buttonConfiguration>
-                            <connections>
-                                <action selector="localFilterButton:" destination="-1" eventType="touchUpInside" id="5wJ-aU-nhI"/>
-                            </connections>
-                        </button>
-                        <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="p5f-K0-wMr">
-                            <rect key="frame" x="110.5" y="0.0" width="102.5" height="30"/>
-                            <color key="tintColor" systemColor="labelColor"/>
-                            <state key="normal" title="Button"/>
-                            <buttonConfiguration key="configuration" style="gray" title="일정설정" cornerStyle="capsule">
-                                <fontDescription key="titleFontDescription" style="UICTFontTextStyleFootnote"/>
-                                <color key="baseBackgroundColor" systemColor="systemGray5Color"/>
-                            </buttonConfiguration>
-                            <connections>
-                                <action selector="dateFilterButton:" destination="-1" eventType="touchUpInside" id="pOL-aO-Oed"/>
-                            </connections>
-                        </button>
-                    </subviews>
-                </stackView>
+                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="1ff-yL-qJn">
+                    <rect key="frame" x="0.0" y="0.0" width="66" height="30"/>
+                    <color key="tintColor" systemColor="labelColor"/>
+                    <state key="normal" title="Button"/>
+                    <buttonConfiguration key="configuration" style="gray" title="지역설정" cornerStyle="capsule">
+                        <fontDescription key="titleFontDescription" style="UICTFontTextStyleFootnote"/>
+                        <color key="baseBackgroundColor" systemColor="systemGray5Color"/>
+                    </buttonConfiguration>
+                    <connections>
+                        <action selector="localFilterButton:" destination="-1" eventType="touchUpInside" id="5wJ-aU-nhI"/>
+                    </connections>
+                </button>
+                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="p5f-K0-wMr">
+                    <rect key="frame" x="73" y="0.0" width="66" height="30"/>
+                    <color key="tintColor" systemColor="labelColor"/>
+                    <state key="normal" title="Button"/>
+                    <buttonConfiguration key="configuration" style="gray" title="일정설정" cornerStyle="capsule">
+                        <fontDescription key="titleFontDescription" style="UICTFontTextStyleFootnote"/>
+                        <color key="baseBackgroundColor" systemColor="systemGray5Color"/>
+                    </buttonConfiguration>
+                    <connections>
+                        <action selector="dateFilterButton:" destination="-1" eventType="touchUpInside" id="pOL-aO-Oed"/>
+                    </connections>
+                </button>
             </subviews>
             <viewLayoutGuide key="safeArea" id="vUN-kp-3ea"/>
             <color key="backgroundColor" systemColor="systemBackgroundColor"/>
             <constraints>
-                <constraint firstItem="7Dh-m2-hwN" firstAttribute="top" secondItem="iN0-l3-epB" secondAttribute="top" id="QhX-X2-Wfc"/>
-                <constraint firstItem="vUN-kp-3ea" firstAttribute="bottom" secondItem="7Dh-m2-hwN" secondAttribute="bottom" id="Wwx-7h-rBJ"/>
-                <constraint firstItem="7Dh-m2-hwN" firstAttribute="leading" secondItem="iN0-l3-epB" secondAttribute="leading" id="Yjf-kd-yZj"/>
-                <constraint firstAttribute="trailing" secondItem="7Dh-m2-hwN" secondAttribute="trailing" id="iBM-kh-L9O"/>
+                <constraint firstItem="1ff-yL-qJn" firstAttribute="top" secondItem="iN0-l3-epB" secondAttribute="top" id="0DC-C4-aIj"/>
+                <constraint firstItem="vUN-kp-3ea" firstAttribute="bottom" secondItem="1ff-yL-qJn" secondAttribute="bottom" id="9JT-gj-9T2"/>
+                <constraint firstItem="vUN-kp-3ea" firstAttribute="bottom" secondItem="p5f-K0-wMr" secondAttribute="bottom" id="9TM-xZ-Xdb"/>
+                <constraint firstItem="p5f-K0-wMr" firstAttribute="leading" secondItem="1ff-yL-qJn" secondAttribute="trailing" constant="7" id="KVw-6X-06c"/>
+                <constraint firstItem="1ff-yL-qJn" firstAttribute="leading" secondItem="iN0-l3-epB" secondAttribute="leading" id="Szv-Yk-T7P"/>
+                <constraint firstItem="p5f-K0-wMr" firstAttribute="top" secondItem="iN0-l3-epB" secondAttribute="top" id="y6W-Xg-K7H"/>
             </constraints>
             <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>
-            <point key="canvasLocation" x="-42.753623188405797" y="-167.41071428571428"/>
+            <point key="canvasLocation" x="63.768115942028992" y="-167.41071428571428"/>
         </view>
     </objects>
     <resources>

--- a/Ninano/Ninano/Views/EventTab/SerchResult/PerformancesViewCell.swift
+++ b/Ninano/Ninano/Views/EventTab/SerchResult/PerformancesViewCell.swift
@@ -19,6 +19,8 @@ final class PerformancesViewCell: UICollectionViewCell {
         self.eventDateLabel.text = event.period?.dateFormatForUI()
         self.eventPlaceLabel.text = event.place
         if let data = event.posterData {
+            // TODO: gaeun 변경
+//            self.eventImageView.image = UIImage(data: data) ?? UIImage(named: "calendarBackground")!
             addImage(UIImage: (UIImage(data: data) ?? UIImage(named: "calendarBackground"))!)
         }
         configuration()
@@ -34,9 +36,13 @@ final class PerformancesViewCell: UICollectionViewCell {
         eventImageView.layer.cornerRadius = 10
         eventImageView.contentMode = .scaleAspectFill
         
+        self.eventImageView.image = UIImage
+
         let cropRect = cropImageSetting(UIImage: UIImage)
-        
         self.eventImageView.image = UIImage.cropImage(rect: cropRect)
+        
+        // 삭제
+//        self.eventImageView.image = UIImage
     }
     
     private func cropImageSetting(UIImage: UIImage) -> CGRect {

--- a/Ninano/Ninano/Views/EventTab/SerchResult/PerformancesViewCell.swift
+++ b/Ninano/Ninano/Views/EventTab/SerchResult/PerformancesViewCell.swift
@@ -21,7 +21,6 @@ final class PerformancesViewCell: UICollectionViewCell {
         if let data = event.posterData {
             let image = (UIImage(data: data) ?? UIImage(named: "calendarBackground"))!
             self.eventImageView.image = resizeImage(image: image)
-            eventImageView.layer.cornerRadius = 10
         }
         configuration()
     }
@@ -37,8 +36,9 @@ final class PerformancesViewCell: UICollectionViewCell {
         UIGraphicsBeginImageContext(CGSize(width: newWidth, height: newHeight))
         image.draw(in: CGRect(x: 0, y: 0, width: newWidth, height: newHeight))
         
-        let newImage = UIGraphicsGetImageFromCurrentImageContext()
+        var newImage = UIGraphicsGetImageFromCurrentImageContext()
         UIGraphicsEndImageContext()
+        newImage = newImage?.withRoundedCorners(radius: 10)
         
         return newImage
     }

--- a/Ninano/Ninano/Views/EventTab/SerchResult/PerformancesViewCell.swift
+++ b/Ninano/Ninano/Views/EventTab/SerchResult/PerformancesViewCell.swift
@@ -19,51 +19,34 @@ final class PerformancesViewCell: UICollectionViewCell {
         self.eventDateLabel.text = event.period?.dateFormatForUI()
         self.eventPlaceLabel.text = event.place
         if let data = event.posterData {
-            // TODO: gaeun 변경
-//            self.eventImageView.image = UIImage(data: data) ?? UIImage(named: "calendarBackground")!
-            addImage(UIImage: (UIImage(data: data) ?? UIImage(named: "calendarBackground"))!)
+            let image = (UIImage(data: data) ?? UIImage(named: "calendarBackground"))!
+            self.eventImageView.image = resizeImage(image: image)
+            eventImageView.layer.cornerRadius = 10
         }
         configuration()
+    }
+    
+    func resizeImage(image: UIImage) -> UIImage? {
+        let screen = UIScreen.main.bounds.width
+        let inset = (25 / 390) * screen
+        let spacing = (14 / 390) * screen
+        
+        let newWidth = (screen - (inset * 2) - spacing) / 2
+        
+        let newHeight = newWidth * ( 4 / 3 )
+        UIGraphicsBeginImageContext(CGSize(width: newWidth, height: newHeight))
+        image.draw(in: CGRect(x: 0, y: 0, width: newWidth, height: newHeight))
+        
+        let newImage = UIGraphicsGetImageFromCurrentImageContext()
+        UIGraphicsEndImageContext()
+        
+        return newImage
     }
     
     private func configuration() {
         eventTitleLabel.font = UIFont.preferredFont(forTextStyle: .caption2, weight: .bold)
         eventDateLabel.font = UIFont.preferredFont(forTextStyle: .caption2, weight: .regular)
         eventPlaceLabel.font = UIFont.preferredFont(forTextStyle: .caption2, weight: .regular)
-    }
-    
-    private func addImage(UIImage: UIImage) {
-        eventImageView.layer.cornerRadius = 10
-        eventImageView.contentMode = .scaleAspectFill
-        
-        self.eventImageView.image = UIImage
-
-        let cropRect = cropImageSetting(UIImage: UIImage)
-        self.eventImageView.image = UIImage.cropImage(rect: cropRect)
-        
-        // 삭제
-//        self.eventImageView.image = UIImage
-    }
-    
-    private func cropImageSetting(UIImage: UIImage) -> CGRect {
-        
-        let screen = UIScreen.main.bounds.width
-        let inset = (25 / 390) * screen
-        let spacing = (14 / 390) * screen
-        
-        let cropWidth = (screen - (inset * 2) - spacing) / 2
-        let cropHeight = ( 4 / 3 ) * cropWidth
-        
-        let imageWidth = UIImage.size.width
-        let imageHeight = UIImage.size.height
-        
-        if imageWidth == 0 { print("imageWidth")}
-        if imageHeight == 0 { print("imageHeight")}
-        
-        let imageX = (imageWidth - cropWidth) / 2
-        let imageY = (imageHeight - cropHeight) / 2
-        
-        return CGRect(x: imageX, y: imageY, width: cropWidth, height: cropHeight)
     }
     
     // MARK: 후에 다시 사용할 수 있어서 남겨두었습니다.

--- a/Ninano/Ninano/Views/EventTab/SerchResult/SearchResult.storyboard
+++ b/Ninano/Ninano/Views/EventTab/SerchResult/SearchResult.storyboard
@@ -28,22 +28,22 @@
                             <collectionView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" dataMode="prototypes" translatesAutoresizingMaskIntoConstraints="NO" id="udG-aU-qED">
                                 <rect key="frame" x="0.0" y="110" width="414" height="752"/>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
-                                <collectionViewFlowLayout key="collectionViewLayout" automaticEstimatedItemSize="YES" minimumLineSpacing="0.0" minimumInteritemSpacing="14" id="rYx-Jx-bsD">
-                                    <size key="itemSize" width="126" height="275"/>
+                                <collectionViewFlowLayout key="collectionViewLayout" minimumLineSpacing="0.0" minimumInteritemSpacing="0.0" id="rYx-Jx-bsD">
+                                    <size key="itemSize" width="126" height="225"/>
                                     <size key="headerReferenceSize" width="0.0" height="0.0"/>
                                     <size key="footerReferenceSize" width="0.0" height="0.0"/>
-                                    <inset key="sectionInset" minX="25" minY="20" maxX="25" maxY="70"/>
+                                    <inset key="sectionInset" minX="24" minY="17" maxX="24" maxY="70"/>
                                 </collectionViewFlowLayout>
                                 <cells>
                                     <collectionViewCell opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" reuseIdentifier="PerformancesViewCell" id="7uK-Yt-BNG" customClass="PerformancesViewCell" customModule="Ninano" customModuleProvider="target">
-                                        <rect key="frame" x="25" y="20" width="126" height="275"/>
+                                        <rect key="frame" x="24" y="17" width="126" height="225"/>
                                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                         <collectionViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" id="rfe-a5-zmD">
-                                            <rect key="frame" x="0.0" y="0.0" width="126" height="275"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="126" height="225"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <button opaque="NO" alpha="0.0" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Bdy-yP-qVp">
-                                                    <rect key="frame" x="86" y="134" width="45" height="31"/>
+                                                    <rect key="frame" x="73" y="122" width="45" height="31"/>
                                                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                                     <state key="normal" title="Button"/>
                                                     <buttonConfiguration key="configuration" style="plain">
@@ -59,22 +59,22 @@
                                                     </buttonConfiguration>
                                                 </button>
                                                 <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="Ef2-X8-K6z">
-                                                    <rect key="frame" x="0.0" y="0.0" width="126" height="195.5"/>
+                                                    <rect key="frame" x="0.0" y="0.0" width="126" height="170.5"/>
                                                 </imageView>
-                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="토요국악토요국악토요국악토요국악토요국악토요국악" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="YWu-Sy-j1s">
-                                                    <rect key="frame" x="0.0" y="202.5" width="126" height="26.5"/>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="토요국악토요국악토요국악토요국악토요국악토요국악" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="YWu-Sy-j1s">
+                                                    <rect key="frame" x="0.0" y="178.5" width="228.5" height="13.5"/>
                                                     <fontDescription key="fontDescription" style="UICTFontTextStyleCaption2"/>
                                                     <nil key="textColor"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
-                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="대전시립연정국악원 작은마당" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="c71-Fo-zm7">
-                                                    <rect key="frame" x="0.0" y="248.5" width="126" height="26.5"/>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="대전시립연정국악원 작은마당" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="c71-Fo-zm7">
+                                                    <rect key="frame" x="0.0" y="211.5" width="127" height="13.5"/>
                                                     <fontDescription key="fontDescription" style="UICTFontTextStyleCaption2"/>
                                                     <nil key="textColor"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="2022.03~11" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Eu8-BF-CrV">
-                                                    <rect key="frame" x="0.0" y="232" width="126" height="13.5"/>
+                                                    <rect key="frame" x="0.0" y="195" width="61.5" height="13.5"/>
                                                     <fontDescription key="fontDescription" style="UICTFontTextStyleCaption2"/>
                                                     <color key="textColor" red="0.50588235294117645" green="0.50588235294117645" blue="0.50588235294117645" alpha="1" colorSpace="calibratedRGB"/>
                                                     <nil key="highlightedColor"/>
@@ -84,19 +84,16 @@
                                                 <constraint firstItem="Ef2-X8-K6z" firstAttribute="leading" secondItem="rfe-a5-zmD" secondAttribute="leading" id="7k3-4v-LcD"/>
                                                 <constraint firstAttribute="trailing" secondItem="Ef2-X8-K6z" secondAttribute="trailing" id="Awe-kx-65R"/>
                                                 <constraint firstItem="c71-Fo-zm7" firstAttribute="leading" secondItem="rfe-a5-zmD" secondAttribute="leading" id="Awf-nO-3O6"/>
-                                                <constraint firstAttribute="trailing" secondItem="Eu8-BF-CrV" secondAttribute="trailing" id="DMU-b7-hnI"/>
                                                 <constraint firstItem="c71-Fo-zm7" firstAttribute="top" secondItem="Eu8-BF-CrV" secondAttribute="bottom" constant="3" id="Hkw-fA-moL"/>
-                                                <constraint firstItem="YWu-Sy-j1s" firstAttribute="top" secondItem="Ef2-X8-K6z" secondAttribute="bottom" constant="7" id="KPv-8D-hfB"/>
                                                 <constraint firstItem="Ef2-X8-K6z" firstAttribute="top" secondItem="rfe-a5-zmD" secondAttribute="top" id="S4f-5E-ale"/>
-                                                <constraint firstAttribute="trailing" secondItem="YWu-Sy-j1s" secondAttribute="trailing" id="XqD-ey-Ru7"/>
+                                                <constraint firstItem="YWu-Sy-j1s" firstAttribute="top" secondItem="Ef2-X8-K6z" secondAttribute="bottom" constant="8" symbolic="YES" id="ehB-YM-6Zd"/>
                                                 <constraint firstItem="Eu8-BF-CrV" firstAttribute="top" secondItem="YWu-Sy-j1s" secondAttribute="bottom" constant="3" id="gI0-lV-fNt"/>
                                                 <constraint firstItem="YWu-Sy-j1s" firstAttribute="leading" secondItem="rfe-a5-zmD" secondAttribute="leading" id="hS0-hp-fhA"/>
                                                 <constraint firstAttribute="bottom" secondItem="c71-Fo-zm7" secondAttribute="bottom" id="msg-lo-jvD"/>
                                                 <constraint firstItem="Eu8-BF-CrV" firstAttribute="leading" secondItem="rfe-a5-zmD" secondAttribute="leading" id="qBv-XN-dxe"/>
-                                                <constraint firstAttribute="trailing" secondItem="c71-Fo-zm7" secondAttribute="trailing" id="uJv-Q4-x0r"/>
                                             </constraints>
                                         </collectionViewCellContentView>
-                                        <size key="customSize" width="126" height="275"/>
+                                        <size key="customSize" width="126" height="225"/>
                                         <connections>
                                             <outlet property="eventDateLabel" destination="Eu8-BF-CrV" id="63i-ui-u7U"/>
                                             <outlet property="eventImageView" destination="Ef2-X8-K6z" id="d1g-IA-gGn"/>

--- a/Ninano/Ninano/Views/EventTab/SerchResult/SearchResult.storyboard
+++ b/Ninano/Ninano/Views/EventTab/SerchResult/SearchResult.storyboard
@@ -18,14 +18,14 @@
                         <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <view contentMode="scaleToFill" ambiguous="YES" translatesAutoresizingMaskIntoConstraints="NO" id="WdU-wj-TDT">
+                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="WdU-wj-TDT">
                                 <rect key="frame" x="0.0" y="104" width="414" height="1"/>
                                 <color key="backgroundColor" systemColor="opaqueSeparatorColor"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="1" id="d7i-3L-lDG"/>
                                 </constraints>
                             </view>
-                            <collectionView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" ambiguous="YES" dataMode="prototypes" translatesAutoresizingMaskIntoConstraints="NO" id="udG-aU-qED">
+                            <collectionView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" dataMode="prototypes" translatesAutoresizingMaskIntoConstraints="NO" id="udG-aU-qED">
                                 <rect key="frame" x="0.0" y="110" width="414" height="752"/>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                 <collectionViewFlowLayout key="collectionViewLayout" automaticEstimatedItemSize="YES" minimumLineSpacing="0.0" minimumInteritemSpacing="14" id="rYx-Jx-bsD">
@@ -151,12 +151,15 @@
                                     <constraint firstAttribute="height" constant="40" id="PfV-hb-vVa"/>
                                 </constraints>
                             </stackView>
-                            <view contentMode="scaleToFill" ambiguous="YES" translatesAutoresizingMaskIntoConstraints="NO" id="9aE-Rg-zDe" customClass="EventFilterButton" customModule="Ninano" customModuleProvider="target">
+                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="9aE-Rg-zDe" customClass="EventFilterButton" customModule="Ninano" customModuleProvider="target">
                                 <rect key="frame" x="30" y="64" width="189" height="30"/>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                                <constraints>
+                                    <constraint firstAttribute="height" constant="30" id="DM1-Jk-g8d"/>
+                                </constraints>
                             </view>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" ambiguous="YES" text="공연이 없습니다 🥹" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="W4i-8p-49O">
-                                <rect key="frame" x="132.5" y="129" width="149" height="23"/>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="공연이 없습니다 🥹" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="W4i-8p-49O">
+                                <rect key="frame" x="132.5" y="152" width="149" height="23"/>
                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
@@ -166,20 +169,20 @@
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <constraints>
                             <constraint firstItem="udG-aU-qED" firstAttribute="leading" secondItem="vDu-zF-Fre" secondAttribute="leading" id="18p-a8-Ytk"/>
+                            <constraint firstAttribute="trailing" secondItem="WdU-wj-TDT" secondAttribute="trailing" id="5B2-Sg-cvC"/>
                             <constraint firstItem="vDu-zF-Fre" firstAttribute="bottom" secondItem="udG-aU-qED" secondAttribute="bottom" id="89X-fM-gLv"/>
                             <constraint firstItem="Wdi-el-Pla" firstAttribute="centerX" secondItem="5EZ-qb-Rvc" secondAttribute="centerX" id="AeU-No-Uga"/>
                             <constraint firstItem="9aE-Rg-zDe" firstAttribute="leading" secondItem="vDu-zF-Fre" secondAttribute="leading" constant="30" id="C3y-s2-9mY"/>
                             <constraint firstItem="vDu-zF-Fre" firstAttribute="bottom" secondItem="Wdi-el-Pla" secondAttribute="bottom" constant="14" id="FTW-8Z-mzB"/>
                             <constraint firstItem="WdU-wj-TDT" firstAttribute="top" secondItem="9aE-Rg-zDe" secondAttribute="bottom" constant="10" id="OD1-v1-7Ze"/>
                             <constraint firstItem="ClT-jf-Z8m" firstAttribute="centerX" secondItem="5EZ-qb-Rvc" secondAttribute="centerX" id="PdA-oV-d2P"/>
-                            <constraint firstItem="W4i-8p-49O" firstAttribute="top" secondItem="WdU-wj-TDT" secondAttribute="bottom" constant="24" id="T0u-xK-hSW"/>
                             <constraint firstItem="vDu-zF-Fre" firstAttribute="trailing" secondItem="9aE-Rg-zDe" secondAttribute="trailing" constant="195" id="UlI-94-hsX"/>
-                            <constraint firstItem="WdU-wj-TDT" firstAttribute="centerX" secondItem="udG-aU-qED" secondAttribute="centerX" id="W9n-Pd-O5r"/>
                             <constraint firstItem="udG-aU-qED" firstAttribute="top" secondItem="WdU-wj-TDT" secondAttribute="bottom" constant="5" id="Wd4-5E-jhn"/>
-                            <constraint firstItem="WdU-wj-TDT" firstAttribute="leading" secondItem="5EZ-qb-Rvc" secondAttribute="leadingMargin" constant="-20" id="bnu-Ce-XsS"/>
                             <constraint firstItem="9aE-Rg-zDe" firstAttribute="top" secondItem="vDu-zF-Fre" secondAttribute="top" constant="20" id="tFs-aK-tOL"/>
                             <constraint firstItem="vDu-zF-Fre" firstAttribute="bottom" secondItem="ClT-jf-Z8m" secondAttribute="bottom" constant="14" id="tOU-2d-59q"/>
                             <constraint firstItem="vDu-zF-Fre" firstAttribute="trailing" secondItem="udG-aU-qED" secondAttribute="trailing" id="uUx-sS-Yn9"/>
+                            <constraint firstItem="WdU-wj-TDT" firstAttribute="leading" secondItem="5EZ-qb-Rvc" secondAttribute="leading" id="v2G-KP-knf"/>
+                            <constraint firstItem="udG-aU-qED" firstAttribute="top" secondItem="W4i-8p-49O" secondAttribute="top" constant="-42" id="wYJ-XZ-PYj"/>
                             <constraint firstItem="W4i-8p-49O" firstAttribute="centerX" secondItem="5EZ-qb-Rvc" secondAttribute="centerX" id="yba-jb-lfK"/>
                         </constraints>
                     </view>

--- a/Ninano/Ninano/Views/EventTab/SerchResult/SearchResult.storyboard
+++ b/Ninano/Ninano/Views/EventTab/SerchResult/SearchResult.storyboard
@@ -59,22 +59,22 @@
                                                     </buttonConfiguration>
                                                 </button>
                                                 <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="Ef2-X8-K6z">
-                                                    <rect key="frame" x="0.0" y="0.0" width="126" height="170.5"/>
+                                                    <rect key="frame" x="0.0" y="0.0" width="126" height="144.5"/>
                                                 </imageView>
-                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="토요국악토요국악토요국악토요국악토요국악토요국악" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="YWu-Sy-j1s">
-                                                    <rect key="frame" x="0.0" y="178.5" width="228.5" height="13.5"/>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="토요국악토요국악토요국악토요국악토요국악토요국악" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="YWu-Sy-j1s">
+                                                    <rect key="frame" x="0.0" y="152.5" width="126" height="26.5"/>
                                                     <fontDescription key="fontDescription" style="UICTFontTextStyleCaption2"/>
                                                     <nil key="textColor"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
-                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="대전시립연정국악원 작은마당" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="c71-Fo-zm7">
-                                                    <rect key="frame" x="0.0" y="211.5" width="127" height="13.5"/>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="대전시립연정국악원 작은마당" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="c71-Fo-zm7">
+                                                    <rect key="frame" x="0.0" y="198.5" width="126" height="26.5"/>
                                                     <fontDescription key="fontDescription" style="UICTFontTextStyleCaption2"/>
                                                     <nil key="textColor"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
-                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="2022.03~11" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Eu8-BF-CrV">
-                                                    <rect key="frame" x="0.0" y="195" width="61.5" height="13.5"/>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="2022.03~11" textAlignment="right" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Eu8-BF-CrV">
+                                                    <rect key="frame" x="0.0" y="182" width="126" height="13.5"/>
                                                     <fontDescription key="fontDescription" style="UICTFontTextStyleCaption2"/>
                                                     <color key="textColor" red="0.50588235294117645" green="0.50588235294117645" blue="0.50588235294117645" alpha="1" colorSpace="calibratedRGB"/>
                                                     <nil key="highlightedColor"/>
@@ -84,13 +84,16 @@
                                                 <constraint firstItem="Ef2-X8-K6z" firstAttribute="leading" secondItem="rfe-a5-zmD" secondAttribute="leading" id="7k3-4v-LcD"/>
                                                 <constraint firstAttribute="trailing" secondItem="Ef2-X8-K6z" secondAttribute="trailing" id="Awe-kx-65R"/>
                                                 <constraint firstItem="c71-Fo-zm7" firstAttribute="leading" secondItem="rfe-a5-zmD" secondAttribute="leading" id="Awf-nO-3O6"/>
+                                                <constraint firstAttribute="trailing" secondItem="c71-Fo-zm7" secondAttribute="trailing" id="CLU-Bp-mB0"/>
                                                 <constraint firstItem="c71-Fo-zm7" firstAttribute="top" secondItem="Eu8-BF-CrV" secondAttribute="bottom" constant="3" id="Hkw-fA-moL"/>
                                                 <constraint firstItem="Ef2-X8-K6z" firstAttribute="top" secondItem="rfe-a5-zmD" secondAttribute="top" id="S4f-5E-ale"/>
+                                                <constraint firstAttribute="trailing" secondItem="Eu8-BF-CrV" secondAttribute="trailing" id="dSk-je-wEg"/>
                                                 <constraint firstItem="YWu-Sy-j1s" firstAttribute="top" secondItem="Ef2-X8-K6z" secondAttribute="bottom" constant="8" symbolic="YES" id="ehB-YM-6Zd"/>
                                                 <constraint firstItem="Eu8-BF-CrV" firstAttribute="top" secondItem="YWu-Sy-j1s" secondAttribute="bottom" constant="3" id="gI0-lV-fNt"/>
                                                 <constraint firstItem="YWu-Sy-j1s" firstAttribute="leading" secondItem="rfe-a5-zmD" secondAttribute="leading" id="hS0-hp-fhA"/>
                                                 <constraint firstAttribute="bottom" secondItem="c71-Fo-zm7" secondAttribute="bottom" id="msg-lo-jvD"/>
                                                 <constraint firstItem="Eu8-BF-CrV" firstAttribute="leading" secondItem="rfe-a5-zmD" secondAttribute="leading" id="qBv-XN-dxe"/>
+                                                <constraint firstAttribute="trailing" secondItem="YWu-Sy-j1s" secondAttribute="trailing" id="uAB-QX-Dsp"/>
                                             </constraints>
                                         </collectionViewCellContentView>
                                         <size key="customSize" width="126" height="225"/>

--- a/Ninano/Ninano/Views/EventTab/SerchResult/SearchResult.storyboard
+++ b/Ninano/Ninano/Views/EventTab/SerchResult/SearchResult.storyboard
@@ -28,7 +28,7 @@
                             <collectionView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" dataMode="prototypes" translatesAutoresizingMaskIntoConstraints="NO" id="udG-aU-qED">
                                 <rect key="frame" x="0.0" y="110" width="414" height="752"/>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
-                                <collectionViewFlowLayout key="collectionViewLayout" minimumLineSpacing="0.0" minimumInteritemSpacing="0.0" id="rYx-Jx-bsD">
+                                <collectionViewFlowLayout key="collectionViewLayout" minimumLineSpacing="13" minimumInteritemSpacing="0.0" id="rYx-Jx-bsD">
                                     <size key="itemSize" width="126" height="225"/>
                                     <size key="headerReferenceSize" width="0.0" height="0.0"/>
                                     <size key="footerReferenceSize" width="0.0" height="0.0"/>
@@ -59,22 +59,22 @@
                                                     </buttonConfiguration>
                                                 </button>
                                                 <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="Ef2-X8-K6z">
-                                                    <rect key="frame" x="0.0" y="0.0" width="126" height="144.5"/>
+                                                    <rect key="frame" x="0.0" y="0.0" width="126" height="170.5"/>
                                                 </imageView>
-                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="토요국악토요국악토요국악토요국악토요국악토요국악" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="YWu-Sy-j1s">
-                                                    <rect key="frame" x="0.0" y="152.5" width="126" height="26.5"/>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="토요국악토요국악토요국악토요국악토요국악토요국악" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="YWu-Sy-j1s">
+                                                    <rect key="frame" x="0.0" y="178.5" width="126" height="13.5"/>
                                                     <fontDescription key="fontDescription" style="UICTFontTextStyleCaption2"/>
                                                     <nil key="textColor"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
-                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="대전시립연정국악원 작은마당" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="c71-Fo-zm7">
-                                                    <rect key="frame" x="0.0" y="198.5" width="126" height="26.5"/>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="대전시립연정국악원 작은마당" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="c71-Fo-zm7">
+                                                    <rect key="frame" x="0.0" y="195" width="126" height="13.5"/>
                                                     <fontDescription key="fontDescription" style="UICTFontTextStyleCaption2"/>
-                                                    <nil key="textColor"/>
+                                                    <color key="textColor" red="0.50588235294117645" green="0.50588235294117645" blue="0.50588235294117645" alpha="1" colorSpace="custom" customColorSpace="calibratedRGB"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
-                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="2022.03~11" textAlignment="right" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Eu8-BF-CrV">
-                                                    <rect key="frame" x="0.0" y="182" width="126" height="13.5"/>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="2022.03~11" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Eu8-BF-CrV">
+                                                    <rect key="frame" x="0.0" y="211.5" width="126" height="13.5"/>
                                                     <fontDescription key="fontDescription" style="UICTFontTextStyleCaption2"/>
                                                     <color key="textColor" red="0.50588235294117645" green="0.50588235294117645" blue="0.50588235294117645" alpha="1" colorSpace="calibratedRGB"/>
                                                     <nil key="highlightedColor"/>
@@ -82,16 +82,16 @@
                                             </subviews>
                                             <constraints>
                                                 <constraint firstItem="Ef2-X8-K6z" firstAttribute="leading" secondItem="rfe-a5-zmD" secondAttribute="leading" id="7k3-4v-LcD"/>
+                                                <constraint firstItem="Eu8-BF-CrV" firstAttribute="top" secondItem="c71-Fo-zm7" secondAttribute="bottom" constant="3" id="872-MM-FNa"/>
                                                 <constraint firstAttribute="trailing" secondItem="Ef2-X8-K6z" secondAttribute="trailing" id="Awe-kx-65R"/>
                                                 <constraint firstItem="c71-Fo-zm7" firstAttribute="leading" secondItem="rfe-a5-zmD" secondAttribute="leading" id="Awf-nO-3O6"/>
                                                 <constraint firstAttribute="trailing" secondItem="c71-Fo-zm7" secondAttribute="trailing" id="CLU-Bp-mB0"/>
-                                                <constraint firstItem="c71-Fo-zm7" firstAttribute="top" secondItem="Eu8-BF-CrV" secondAttribute="bottom" constant="3" id="Hkw-fA-moL"/>
                                                 <constraint firstItem="Ef2-X8-K6z" firstAttribute="top" secondItem="rfe-a5-zmD" secondAttribute="top" id="S4f-5E-ale"/>
+                                                <constraint firstItem="c71-Fo-zm7" firstAttribute="top" secondItem="YWu-Sy-j1s" secondAttribute="bottom" constant="3" id="ZT0-Ka-zOg"/>
                                                 <constraint firstAttribute="trailing" secondItem="Eu8-BF-CrV" secondAttribute="trailing" id="dSk-je-wEg"/>
                                                 <constraint firstItem="YWu-Sy-j1s" firstAttribute="top" secondItem="Ef2-X8-K6z" secondAttribute="bottom" constant="8" symbolic="YES" id="ehB-YM-6Zd"/>
-                                                <constraint firstItem="Eu8-BF-CrV" firstAttribute="top" secondItem="YWu-Sy-j1s" secondAttribute="bottom" constant="3" id="gI0-lV-fNt"/>
                                                 <constraint firstItem="YWu-Sy-j1s" firstAttribute="leading" secondItem="rfe-a5-zmD" secondAttribute="leading" id="hS0-hp-fhA"/>
-                                                <constraint firstAttribute="bottom" secondItem="c71-Fo-zm7" secondAttribute="bottom" id="msg-lo-jvD"/>
+                                                <constraint firstAttribute="bottom" secondItem="Eu8-BF-CrV" secondAttribute="bottom" id="jwh-PO-qsk"/>
                                                 <constraint firstItem="Eu8-BF-CrV" firstAttribute="leading" secondItem="rfe-a5-zmD" secondAttribute="leading" id="qBv-XN-dxe"/>
                                                 <constraint firstAttribute="trailing" secondItem="YWu-Sy-j1s" secondAttribute="trailing" id="uAB-QX-Dsp"/>
                                             </constraints>

--- a/Ninano/Ninano/Views/EventTab/SerchResult/SearchResult.storyboard
+++ b/Ninano/Ninano/Views/EventTab/SerchResult/SearchResult.storyboard
@@ -5,7 +5,6 @@
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="20020"/>
         <capability name="Image references" minToolsVersion="12.0"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
-        <capability name="Stack View standard spacing" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="collection view cell content view" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -19,77 +18,30 @@
                         <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="WdU-wj-TDT">
+                            <view contentMode="scaleToFill" ambiguous="YES" translatesAutoresizingMaskIntoConstraints="NO" id="WdU-wj-TDT">
                                 <rect key="frame" x="0.0" y="104" width="414" height="1"/>
                                 <color key="backgroundColor" systemColor="opaqueSeparatorColor"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="1" id="d7i-3L-lDG"/>
                                 </constraints>
                             </view>
-                            <collectionView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" dataMode="prototypes" translatesAutoresizingMaskIntoConstraints="NO" id="udG-aU-qED">
+                            <collectionView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" ambiguous="YES" dataMode="prototypes" translatesAutoresizingMaskIntoConstraints="NO" id="udG-aU-qED">
                                 <rect key="frame" x="0.0" y="110" width="414" height="752"/>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                 <collectionViewFlowLayout key="collectionViewLayout" automaticEstimatedItemSize="YES" minimumLineSpacing="0.0" minimumInteritemSpacing="14" id="rYx-Jx-bsD">
-                                    <size key="itemSize" width="126" height="216"/>
+                                    <size key="itemSize" width="126" height="275"/>
                                     <size key="headerReferenceSize" width="0.0" height="0.0"/>
                                     <size key="footerReferenceSize" width="0.0" height="0.0"/>
                                     <inset key="sectionInset" minX="25" minY="20" maxX="25" maxY="70"/>
                                 </collectionViewFlowLayout>
                                 <cells>
                                     <collectionViewCell opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" reuseIdentifier="PerformancesViewCell" id="7uK-Yt-BNG" customClass="PerformancesViewCell" customModule="Ninano" customModuleProvider="target">
-                                        <rect key="frame" x="25" y="20" width="126" height="216"/>
+                                        <rect key="frame" x="25" y="20" width="126" height="275"/>
                                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                         <collectionViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" id="rfe-a5-zmD">
-                                            <rect key="frame" x="0.0" y="0.0" width="126" height="216"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="126" height="275"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
-                                                <stackView opaque="NO" contentMode="scaleToFill" ambiguous="YES" axis="vertical" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="2ty-Gg-Qjl">
-                                                    <rect key="frame" x="0.0" y="0.0" width="127" height="212"/>
-                                                    <subviews>
-                                                        <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" ambiguous="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Ef2-X8-K6z">
-                                                            <rect key="frame" x="0.0" y="0.0" width="127" height="174"/>
-                                                        </imageView>
-                                                        <stackView opaque="NO" contentMode="scaleToFill" ambiguous="YES" axis="vertical" alignment="top" spacing="3" translatesAutoresizingMaskIntoConstraints="NO" id="rJU-aH-WKs">
-                                                            <rect key="frame" x="0.0" y="182" width="127" height="30"/>
-                                                            <subviews>
-                                                                <stackView opaque="NO" contentMode="scaleToFill" spacingType="standard" translatesAutoresizingMaskIntoConstraints="NO" id="5lN-WM-NmO">
-                                                                    <rect key="frame" x="0.0" y="0.0" width="127" height="13.5"/>
-                                                                    <subviews>
-                                                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" ambiguous="YES" text="토요국악" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="YWu-Sy-j1s">
-                                                                            <rect key="frame" x="0.0" y="0.0" width="57.5" height="13.5"/>
-                                                                            <fontDescription key="fontDescription" style="UICTFontTextStyleCaption2"/>
-                                                                            <nil key="textColor"/>
-                                                                            <nil key="highlightedColor"/>
-                                                                        </label>
-                                                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" ambiguous="YES" text="2022.03~11" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Eu8-BF-CrV">
-                                                                            <rect key="frame" x="65.5" y="0.0" width="61.5" height="13.5"/>
-                                                                            <fontDescription key="fontDescription" style="UICTFontTextStyleCaption2"/>
-                                                                            <color key="textColor" red="0.50588235294117645" green="0.50588235294117645" blue="0.50588235294117645" alpha="1" colorSpace="calibratedRGB"/>
-                                                                            <nil key="highlightedColor"/>
-                                                                        </label>
-                                                                    </subviews>
-                                                                    <constraints>
-                                                                        <constraint firstAttribute="trailing" secondItem="Eu8-BF-CrV" secondAttribute="trailing" id="KYX-bL-4x7"/>
-                                                                        <constraint firstItem="YWu-Sy-j1s" firstAttribute="leading" secondItem="5lN-WM-NmO" secondAttribute="leading" id="iFj-K8-xQ6"/>
-                                                                    </constraints>
-                                                                </stackView>
-                                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="대전시립연정국악원 작은마당" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="c71-Fo-zm7">
-                                                                    <rect key="frame" x="0.0" y="16.5" width="127" height="13.5"/>
-                                                                    <fontDescription key="fontDescription" style="UICTFontTextStyleCaption2"/>
-                                                                    <nil key="textColor"/>
-                                                                    <nil key="highlightedColor"/>
-                                                                </label>
-                                                            </subviews>
-                                                            <constraints>
-                                                                <constraint firstAttribute="trailing" secondItem="5lN-WM-NmO" secondAttribute="trailing" id="Vtg-bY-dfp"/>
-                                                            </constraints>
-                                                        </stackView>
-                                                    </subviews>
-                                                    <constraints>
-                                                        <constraint firstAttribute="trailing" secondItem="rJU-aH-WKs" secondAttribute="trailing" id="HVd-7s-inE"/>
-                                                        <constraint firstItem="rJU-aH-WKs" firstAttribute="leading" secondItem="2ty-Gg-Qjl" secondAttribute="leading" id="VJe-RF-XeF"/>
-                                                    </constraints>
-                                                </stackView>
                                                 <button opaque="NO" alpha="0.0" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Bdy-yP-qVp">
                                                     <rect key="frame" x="86" y="134" width="45" height="31"/>
                                                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
@@ -106,9 +58,45 @@
                                                         <color key="baseForegroundColor" white="0.33333333333333331" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                     </buttonConfiguration>
                                                 </button>
+                                                <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="Ef2-X8-K6z">
+                                                    <rect key="frame" x="0.0" y="0.0" width="126" height="195.5"/>
+                                                </imageView>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="토요국악토요국악토요국악토요국악토요국악토요국악" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="YWu-Sy-j1s">
+                                                    <rect key="frame" x="0.0" y="202.5" width="126" height="26.5"/>
+                                                    <fontDescription key="fontDescription" style="UICTFontTextStyleCaption2"/>
+                                                    <nil key="textColor"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="대전시립연정국악원 작은마당" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="c71-Fo-zm7">
+                                                    <rect key="frame" x="0.0" y="248.5" width="126" height="26.5"/>
+                                                    <fontDescription key="fontDescription" style="UICTFontTextStyleCaption2"/>
+                                                    <nil key="textColor"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="2022.03~11" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Eu8-BF-CrV">
+                                                    <rect key="frame" x="0.0" y="232" width="126" height="13.5"/>
+                                                    <fontDescription key="fontDescription" style="UICTFontTextStyleCaption2"/>
+                                                    <color key="textColor" red="0.50588235294117645" green="0.50588235294117645" blue="0.50588235294117645" alpha="1" colorSpace="calibratedRGB"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
                                             </subviews>
+                                            <constraints>
+                                                <constraint firstItem="Ef2-X8-K6z" firstAttribute="leading" secondItem="rfe-a5-zmD" secondAttribute="leading" id="7k3-4v-LcD"/>
+                                                <constraint firstAttribute="trailing" secondItem="Ef2-X8-K6z" secondAttribute="trailing" id="Awe-kx-65R"/>
+                                                <constraint firstItem="c71-Fo-zm7" firstAttribute="leading" secondItem="rfe-a5-zmD" secondAttribute="leading" id="Awf-nO-3O6"/>
+                                                <constraint firstAttribute="trailing" secondItem="Eu8-BF-CrV" secondAttribute="trailing" id="DMU-b7-hnI"/>
+                                                <constraint firstItem="c71-Fo-zm7" firstAttribute="top" secondItem="Eu8-BF-CrV" secondAttribute="bottom" constant="3" id="Hkw-fA-moL"/>
+                                                <constraint firstItem="YWu-Sy-j1s" firstAttribute="top" secondItem="Ef2-X8-K6z" secondAttribute="bottom" constant="7" id="KPv-8D-hfB"/>
+                                                <constraint firstItem="Ef2-X8-K6z" firstAttribute="top" secondItem="rfe-a5-zmD" secondAttribute="top" id="S4f-5E-ale"/>
+                                                <constraint firstAttribute="trailing" secondItem="YWu-Sy-j1s" secondAttribute="trailing" id="XqD-ey-Ru7"/>
+                                                <constraint firstItem="Eu8-BF-CrV" firstAttribute="top" secondItem="YWu-Sy-j1s" secondAttribute="bottom" constant="3" id="gI0-lV-fNt"/>
+                                                <constraint firstItem="YWu-Sy-j1s" firstAttribute="leading" secondItem="rfe-a5-zmD" secondAttribute="leading" id="hS0-hp-fhA"/>
+                                                <constraint firstAttribute="bottom" secondItem="c71-Fo-zm7" secondAttribute="bottom" id="msg-lo-jvD"/>
+                                                <constraint firstItem="Eu8-BF-CrV" firstAttribute="leading" secondItem="rfe-a5-zmD" secondAttribute="leading" id="qBv-XN-dxe"/>
+                                                <constraint firstAttribute="trailing" secondItem="c71-Fo-zm7" secondAttribute="trailing" id="uJv-Q4-x0r"/>
+                                            </constraints>
                                         </collectionViewCellContentView>
-                                        <size key="customSize" width="126" height="216"/>
+                                        <size key="customSize" width="126" height="275"/>
                                         <connections>
                                             <outlet property="eventDateLabel" destination="Eu8-BF-CrV" id="63i-ui-u7U"/>
                                             <outlet property="eventImageView" destination="Ef2-X8-K6z" id="d1g-IA-gGn"/>
@@ -166,11 +154,8 @@
                             <view contentMode="scaleToFill" ambiguous="YES" translatesAutoresizingMaskIntoConstraints="NO" id="9aE-Rg-zDe" customClass="EventFilterButton" customModule="Ninano" customModuleProvider="target">
                                 <rect key="frame" x="30" y="64" width="189" height="30"/>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
-                                <constraints>
-                                    <constraint firstAttribute="height" constant="30" id="2K9-18-f65"/>
-                                </constraints>
                             </view>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="공연이 없습니다 🥹" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="W4i-8p-49O">
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" ambiguous="YES" text="공연이 없습니다 🥹" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="W4i-8p-49O">
                                 <rect key="frame" x="132.5" y="129" width="149" height="23"/>
                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
                                 <nil key="textColor"/>
@@ -181,13 +166,14 @@
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <constraints>
                             <constraint firstItem="udG-aU-qED" firstAttribute="leading" secondItem="vDu-zF-Fre" secondAttribute="leading" id="18p-a8-Ytk"/>
+                            <constraint firstItem="vDu-zF-Fre" firstAttribute="bottom" secondItem="udG-aU-qED" secondAttribute="bottom" id="89X-fM-gLv"/>
                             <constraint firstItem="Wdi-el-Pla" firstAttribute="centerX" secondItem="5EZ-qb-Rvc" secondAttribute="centerX" id="AeU-No-Uga"/>
                             <constraint firstItem="9aE-Rg-zDe" firstAttribute="leading" secondItem="vDu-zF-Fre" secondAttribute="leading" constant="30" id="C3y-s2-9mY"/>
                             <constraint firstItem="vDu-zF-Fre" firstAttribute="bottom" secondItem="Wdi-el-Pla" secondAttribute="bottom" constant="14" id="FTW-8Z-mzB"/>
-                            <constraint firstItem="vDu-zF-Fre" firstAttribute="bottom" secondItem="udG-aU-qED" secondAttribute="bottom" id="KBL-em-rA3"/>
                             <constraint firstItem="WdU-wj-TDT" firstAttribute="top" secondItem="9aE-Rg-zDe" secondAttribute="bottom" constant="10" id="OD1-v1-7Ze"/>
                             <constraint firstItem="ClT-jf-Z8m" firstAttribute="centerX" secondItem="5EZ-qb-Rvc" secondAttribute="centerX" id="PdA-oV-d2P"/>
                             <constraint firstItem="W4i-8p-49O" firstAttribute="top" secondItem="WdU-wj-TDT" secondAttribute="bottom" constant="24" id="T0u-xK-hSW"/>
+                            <constraint firstItem="vDu-zF-Fre" firstAttribute="trailing" secondItem="9aE-Rg-zDe" secondAttribute="trailing" constant="195" id="UlI-94-hsX"/>
                             <constraint firstItem="WdU-wj-TDT" firstAttribute="centerX" secondItem="udG-aU-qED" secondAttribute="centerX" id="W9n-Pd-O5r"/>
                             <constraint firstItem="udG-aU-qED" firstAttribute="top" secondItem="WdU-wj-TDT" secondAttribute="bottom" constant="5" id="Wd4-5E-jhn"/>
                             <constraint firstItem="WdU-wj-TDT" firstAttribute="leading" secondItem="5EZ-qb-Rvc" secondAttribute="leadingMargin" constant="-20" id="bnu-Ce-XsS"/>

--- a/Ninano/Ninano/extension/UIImage.swift
+++ b/Ninano/Ninano/extension/UIImage.swift
@@ -23,4 +23,20 @@ extension UIImage {
         UIGraphicsEndImageContext()
         return newImage
     }
+    func withRoundedCorners(radius: CGFloat? = nil) -> UIImage? {
+        let maxRadius = min(size.width, size.height) / 2
+        let cornerRadius: CGFloat
+        if let radius = radius, radius > 0 && radius <= maxRadius {
+            cornerRadius = radius
+        } else {
+            cornerRadius = maxRadius
+        }
+        UIGraphicsBeginImageContextWithOptions(size, false, scale)
+        let rect = CGRect(origin: .zero, size: size)
+        UIBezierPath(roundedRect: rect, cornerRadius: cornerRadius).addClip()
+        draw(in: rect)
+        let image = UIGraphicsGetImageFromCurrentImageContext()
+        UIGraphicsEndImageContext()
+        return image
+    }
 }


### PR DESCRIPTION
# Issue Number
🔒 Close #95
🔒 Close #89
🔒 Close #96

## Pull Request 내용 (변경 및 추가된 사항들)
SearchResultView에 image 잘림 현상해결 
SearchResultView Autolayout을 적용
SearchResultView color Hifi랑 동일하게 하기 

## Review points
- write here

## 관련 사진 gif 및 (Optional)
<img width="703" alt="스크린샷 2022-07-31 오후 5 52 57" src="https://user-images.githubusercontent.com/82457928/182018726-ab59a0d0-5500-4535-bf25-5a0b7b61b617.png">
<img width="674" alt="스크린샷 2022-07-31 오후 5 53 10" src="https://user-images.githubusercontent.com/82457928/182018714-3bcf11d2-2aab-4084-bd2a-a7db018055e7.png">


## Checklist

- [x] merge할 branch를 확인했나요?
- [x] coding conventions을 지켰나요?
- [x] 이 PR에 관계없는 변경사항들이 없나요?
- [x] PR 날리는 코드를 self 리뷰 했나요?
